### PR TITLE
add the support of Media Segments specified by relative URL

### DIFF
--- a/download-hls.sh
+++ b/download-hls.sh
@@ -38,12 +38,13 @@ while read line; do
     fi
     
     if [[ $status == "reading" ]]
-    then
-		if [[ $line == */* ]] # if the Media Segment URI is an URL
+	then
+		if [[ $line == */* ]] # if the Media Segment URI is an absolute URL
 		then
 	        curl -s --show-error "${line}" >> "$filename"
-		else # is an URN, guess its url with safari's logic
-			curl -s --show-error "${path}/${line}" >> "$filename"
+		else # is a relative URL
+			curl -s --show-error "${path}/${line}" > "$line"
+			cat "$line" >> "$filename"
 		fi
         status="begin"
         echo "$count segment(s) downloaded..."

--- a/download-hls.sh
+++ b/download-hls.sh
@@ -19,6 +19,15 @@ echo "Save file to $filename"
 status="begin"
 count=1
 url="$1"
+
+if [[ $url =~ (.*)/[^/]* ]]
+then
+	path=${BASH_REMATCH[1]}
+else
+	echo "the URL arguments is error."
+	exit 1
+fi
+
 curl "$url" > temp.m3u8
 cat temp.m3u8 | \
 while read line; do
@@ -30,7 +39,12 @@ while read line; do
     
     if [[ $status == "reading" ]]
     then
-        curl -s --show-error "${line}" >> "$filename"
+		if [[ $line == */* ]] # if the Media Segment URI is an URL
+		then
+	        curl -s --show-error "${line}" >> "$filename"
+		else # is an URN, guess its url with safari's logic
+			curl -s --show-error "${path}/${line}" >> "$filename"
+		fi
         status="begin"
         echo "$count segment(s) downloaded..."
         let "count += 1"
@@ -45,3 +59,4 @@ while read line; do
         exit 0
     fi
 done
+


### PR DESCRIPTION
- Safari's logic: add the m3u8's url's prefix to the urn.
- get the url prefix by bash's '=~' binary operator, and name it path.